### PR TITLE
github: Add sparse diffing for merge branch

### DIFF
--- a/.github/problem-matchers/sparse.json
+++ b/.github/problem-matchers/sparse.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+	{
+	    "owner": "powerpc-sparse",
+	    "pattern": [
+		{
+		    "regexp": "^(?:\\+|-)?(?:/linux/)?(.*):(\\d+):(\\d+):\\s+(error|warning):\\s+(.*)$",
+		    "file": 1,
+		    "line": 2,
+		    "column": 3,
+		    "severity": 4,
+		    "message": 5
+		}
+	    ]
+	}
+    ]
+}

--- a/.github/workflows/powerpc-sparse.yml
+++ b/.github/workflows/powerpc-sparse.yml
@@ -69,8 +69,24 @@ jobs:
         mkdir -p ~/.ccache
         ./arch/powerpc/tools/ci-build.sh
 
-    - name: powerpc sparse errors
-      run: grep /linux/arch/powerpc ~/output/sparse.log
+    - name: Get sparse results from base tree
+      continue-on-error: true
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: powerpc-sparse.yml
+        workflow_conclusion: success
+        branch: merge # Requires the merge branch to be built once before this will work
+        name: sparse-${{ matrix.defconfig }}-${{ matrix.image }}.log
+        path: ~/base_logs
+
+    - name: Register sparse problem matcher
+      run: echo "::add-matcher::.github/problem-matchers/sparse.json"
+
+    - name: Compare sparse results with base
+      run: |
+        wget https://github.com/daxtens/smart-sparse-diff/raw/master/smart-sparse-diff.py
+        bash -c 'if [ ! -f ~/base_logs/sparse.log ]; then mkdir -p ~/base_logs && cp ~/output/sparse.log ~/base_logs/; fi'
+        python3 smart-sparse-diff.py ~/base_logs/sparse.log ~/output/sparse.log | tee -a ~/output/sparse-diff.log
 
     - name: Archive artifacts
       uses: actions/upload-artifact@v3
@@ -78,3 +94,4 @@ jobs:
         name: sparse-${{ matrix.defconfig }}-${{ matrix.image }}.log
         path: |
           ~/output/sparse.log
+          ~/output/sparse-diff.log


### PR DESCRIPTION
This is just what I've jankily been doing, so it'd be a good time to think about how to do it "properly".

Ideally I can factor out the merge branch so anyone cloning the repo and adding commits on top will have those commits compared to whatever the source branch is but I'm not entirely sure how that would work.

We should probably also add the smart-sparse-diff script to the tree to remove the dependency on dja's repo.