### PR TITLE
powerpc/ci: Add ppce500 machine to kernel+qemu workflows

### DIFF
--- a/.github/workflows/powerpc-kernel+qemu.yml
+++ b/.github/workflows/powerpc-kernel+qemu.yml
@@ -155,6 +155,13 @@ jobs:
             old-image: korg-8.1.0
             new-image: fedora-40
 
+          - defconfig: corenet32_smp_defconfig
+            machine: e500mc
+            packages: qemu-system-ppc openbios-ppc
+            rootfs: ppc-rootfs.cpio.gz
+            old-image: korg-8.1.0
+            new-image: fedora-40
+
           - defconfig: g5_defconfig
             machine: g5
             packages: qemu-system-ppc64 openbios-ppc


### PR DESCRIPTION
Recently we saw an issue with hugetlb max order folio pages. The warning was getting reported on ppc64e but the problem also existed on ppc32 for ppce500 machine type and e500mc cpu type for it's unconventional max order of folio for hugetlbfs.

Hence enable kernel+qemu boot test with ppce500 machine as well to catch such corner case issues in future.

More details about this discussion is here... 
https://lore.kernel.org/linuxppc-dev/87ecq952pe.ritesh.list@gmail.com/