### PR TITLE
powerpc/ci: Fix boot issues with corenet32_smp_defconfig for e500mc

### DIFF
--- a/.github/workflows/powerpc-kernel+qemu.yml
+++ b/.github/workflows/powerpc-kernel+qemu.yml
@@ -159,7 +159,6 @@ jobs:
             machine: e500mc
             packages: qemu-system-ppc openbios-ppc
             rootfs: ppc-rootfs.cpio.gz
-            old-image: korg-8.1.0
             new-image: fedora-40
 
           - defconfig: g5_defconfig
@@ -211,10 +210,12 @@ jobs:
     - uses: actions/download-artifact@v4
       with:
         name: ${{ matrix.defconfig }}-${{ matrix.old-image }}
+      if: matrix.old-image != ''
 
     - name: Run qemu-${{ matrix.machine }} with ${{ matrix.old-image }} build kernel
       run: ./scripts/boot/qemu-${{ matrix.machine }}
+      if: matrix.old-image != ''
 
     - name: Run qemu-${{ matrix.machine_2 }} with ${{ matrix.old-image }} build kernel
       run: ./scripts/boot/qemu-${{ matrix.machine_2 }}
-      if: matrix.machine_2 != ''
+      if: matrix.machine_2 != '' && matrix.old-image != ''


### PR DESCRIPTION
As mentioned in the commit msg, we will need this change, since in the build matrix for corenet32_smp_defconfig we never specify korg-8.1.0 image. So download artifact step will fail for korg-8.1.0 image. 

So this patch removes korg-8.1.0 from kernel boot job, and adds conditional check in the kernel booting steps to only run those steps when old-image is not an empty string.




